### PR TITLE
Fixed minor typos in comments

### DIFF
--- a/src/Bndr.ts
+++ b/src/Bndr.ts
@@ -852,7 +852,7 @@ export class Bndr<T = any> {
 	}
 
 	/**
-	 * Collection of “value types”, which defines algebraic structure such as add, scale, and norm. Some of {@link Bndr} instances have a type information so that they can be scaled or lerped without passing function explicily. See {@link Bndr.as} and {@link Bndr#map} for more details.
+	 * Collection of “value types”, which defines algebraic structure such as add, scale, and norm. Some of {@link Bndr} instances have a type information so that they can be scaled or lerped without passing a function explicitly. See {@link Bndr.as} and {@link Bndr#map} for more details.
 	 * @group Value Type Indicators
 	 */
 	static type = {

--- a/src/Bndr.ts
+++ b/src/Bndr.ts
@@ -536,7 +536,7 @@ export class Bndr<T = any> {
 	}
 
 	/**
-	 * Creates an emitter with a spring effect appliec to the current emitter object
+	 * Creates an emitter with a spring effect applied to the current emitter object
 	 * @param options Options for the spring effect.
 	 * @returns The new emitter
 	 */

--- a/src/generator/pointer.ts
+++ b/src/generator/pointer.ts
@@ -144,7 +144,7 @@ export class PointerBndr extends TargetedPointerBndr {
 
 	/**
 	 *
-	 * @param target A DOM element to watch the pointr event
+	 * @param target A DOM element to watch the pointer event
 	 * @returns
 	 * @group Generators
 	 */


### PR DESCRIPTION
Hello, I was reading through the source and noticed a few minor typos throughout some of the comments and thought I'd submit a quick PR to fix them.

I also noticed a few typos in the typedoc generated docs in the `docs/classes` folder, but I get a handful of errors when trying to run the `build:doc` command, so I decided to leave those alone but just wanted to give a heads up.

Thanks!